### PR TITLE
#515: Port partition aware policy to C#

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # DataStax C# Driver for Apache Cassandra
 
-A modern, [feature-rich][features] and highly tunable C# client library for Apache Cassandra (1.2+) using exclusively Cassandra's binary protocol and Cassandra Query Language v3. _Use the [DSE C# driver][dse-driver] for better compatibility and support for DataStax Enterprise_.
+A modern, [feature-rich][features] and highly tunable C# client library for Apache Cassandra (1.2+) using exclusively Cassandra's binary protocol and Cassandra Query Language v3.
 
 The driver supports .NET Framework 4.5+ and .NET Core 1+.
 
@@ -36,7 +36,7 @@ PM> Install-Package CassandraCSharpDriver
 
 ## Getting Help
 
-You can use the project [Mailing list][mailinglist] or create a ticket on the [Jira issue tracker][jira]. Additionally, you can use the `#datastax-drivers` channel in the [DataStax Academy Slack][slack].
+You can use the project [Mailing list][mailinglist] or create a ticket on the [Jira issue tracker][jira].
 
 ## Upgrading from previous versions
 

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Net;

--- a/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/ClusterTests.cs
@@ -212,6 +212,14 @@ namespace Cassandra.IntegrationTests.Core
             {
                 return _cluster.AllHosts();
             }
+
+            public bool RequiresPartitionMap
+            {
+                get
+                {
+                    return false;
+                }
+            }
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -13,6 +13,19 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
 
 using Cassandra.IntegrationTests.TestBase;
 using Cassandra.IntegrationTests.TestClusterManagement;

--- a/src/Cassandra.IntegrationTests/Core/SessionTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SessionTests.cs
@@ -362,6 +362,14 @@ namespace Cassandra.IntegrationTests.Core
             {
                 return _childPolicy.NewQueryPlan(keyspace, query);
             }
+
+            public bool RequiresPartitionMap
+            {
+                get
+                {
+                    return false;
+                }
+            }
         }
 
 

--- a/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionShortTests.cs
@@ -208,6 +208,14 @@ namespace Cassandra.IntegrationTests.Core
                     yield return host;
                 }
             }
+
+            public bool RequiresPartitionMap
+            {
+                get
+                {
+                    return false;
+                }
+            }
         }
     }
 }

--- a/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionShortTests.cs
+++ b/src/Cassandra.IntegrationTests/Core/SpeculativeExecutionShortTests.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+
+using System;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -682,6 +682,14 @@ namespace Cassandra.Tests
             {
                 return !_useRoundRobin ? _hosts : _childPolicy.NewQueryPlan(keyspace, query);
             }
+
+            public bool RequiresPartitionMap
+            {
+                get
+                {
+                    return false;
+                }
+            }
         }
     }
 }

--- a/src/Cassandra.Tests/TestHelper.cs
+++ b/src/Cassandra.Tests/TestHelper.cs
@@ -1,4 +1,18 @@
-﻿using NUnit.Framework;
+﻿//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+
+using NUnit.Framework;
 using System;
 using System.Collections;
 using System.Collections.Concurrent;

--- a/src/Cassandra.YugaByte.Tests/Cassandra.YugaByte.Tests.csproj
+++ b/src/Cassandra.YugaByte.Tests/Cassandra.YugaByte.Tests.csproj
@@ -1,0 +1,36 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PublicSign>false</PublicSign>
+    <AssemblyName>Cassandra.Tests</AssemblyName>
+    <AssemblyOriginatorKeyFile>../../build/datastax.snk</AssemblyOriginatorKeyFile>
+    <SignAssembly>true</SignAssembly>
+    <PackageId>Cassandra.Tests</PackageId>
+    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Cassandra\Cassandra.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.DotNet.InternalAbstractions" Version="1.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
+    <PackageReference Include="Moq" Version="4.7.99" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="NUnit" Version="3.7.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.10.0" />
+    <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+    <Reference Include="System.Data" />
+    <Reference Include="System.Numerics" />
+    <Reference Include="System" />
+    <Reference Include="Microsoft.CSharp" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">
+    <DefineConstants>$(DefineConstants);NETCORE</DefineConstants>
+  </PropertyGroup>
+</Project>

--- a/src/Cassandra.YugaByte.Tests/JsonTest.cs
+++ b/src/Cassandra.YugaByte.Tests/JsonTest.cs
@@ -1,0 +1,421 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using NUnit.Framework;
+using Newtonsoft.Json.Linq;
+
+namespace Cassandra.YugaByte.Tests
+{
+    [TestFixture]
+    class JsonTest
+    {
+        private ICluster _cluster;
+        private ISession _session;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Verbose;
+            var ip = Environment.GetEnvironmentVariable("YB_CLUSTER_ADDRESS");
+            _cluster = Cluster.Builder().AddContactPoint(ip).Build();
+            _session = _cluster.Connect();
+            _session.Execute("CREATE KEYSPACE IF NOT EXISTS test");
+            _session.Execute("USE test");
+        }
+
+        [Test]
+        public void Basic()
+        {
+            _session.Execute("DROP TABLE IF EXISTS books");
+            _session.Execute("CREATE TABLE books (id int PRIMARY KEY, details jsonb)");
+
+            var ps = _session.Prepare("INSERT INTO books (id, details) VALUES (?, ?)");
+
+            var details = new JObject();
+            details.Add("name", new JValue("Macbeth"));
+            var author = new JObject();
+            author.Add("first_name", new JValue("William"));
+            author.Add("last_name", new JValue("Shakespeare"));
+            var statement = ps.Bind(1, details.ToString());
+            _session.Execute(statement);
+
+            ps = _session.Prepare("SELECT details FROM books WHERE id=?");
+            var rs = _session.Execute(ps.Bind(1));
+            foreach (var row in rs)
+            {
+                var parsedDetails = JObject.Parse(row.GetValue<string>("details"));
+                Assert.AreEqual(details, parsedDetails);
+            }
+        }
+
+        [Test]
+        public void Json()
+        {
+            const string json =
+            "{ " +
+              "\"b\" : 1," +
+              "\"a2\" : {}," +
+              "\"a3\" : \"\"," +
+              "\"a1\" : [1, 2, 3.0, false, true, { \"k1\" : 1, \"k2\" : [100, 200, 300], \"k3\" : true}]," +
+              "\"a\" :" +
+              "{" +
+                "\"d\" : true," +
+                "\"q\" :" +
+                  "{" +
+                    "\"p\" : 4294967295," +
+                    "\"r\" : -2147483648," +
+                    "\"s\" : 2147483647" +
+                  "}," +
+                "\"g\" : -100," +
+                "\"c\" : false," +
+                "\"f\" : \"hello\"," +
+                "\"x\" : 2.0," +
+                "\"y\" : 9223372036854775807," +
+                "\"z\" : -9223372036854775808," +
+                "\"u\" : 18446744073709551615," +
+                "\"l\" : 2147483647.123123e+75," +
+                "\"e\" : null" +
+              "}" +
+            "}";
+
+            _session.Execute("DROP TABLE IF EXISTS test_json");
+            _session.Execute("CREATE TABLE test_json(c1 int, c2 jsonb, PRIMARY KEY(c1))");
+            _session.Execute(_session.Prepare("INSERT INTO test_json(c1, c2) values (1, ?)").Bind(json));
+            _session.Execute("INSERT INTO test_json(c1, c2) values (2, '\"abc\"');");
+            _session.Execute("INSERT INTO test_json(c1, c2) values (3, '3');");
+            _session.Execute("INSERT INTO test_json(c1, c2) values (4, 'true');");
+            _session.Execute("INSERT INTO test_json(c1, c2) values (5, 'false');");
+            _session.Execute("INSERT INTO test_json(c1, c2) values (6, 'null');");
+            _session.Execute("INSERT INTO test_json(c1, c2) values (7, '2.0');");
+            _session.Execute("INSERT INTO test_json(c1, c2) values (8, '{\"b\" : 1}');");
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c1 = 1"));
+
+            // Invalid inserts.
+            ExecuteInvalid("INSERT INTO test_json(c1, c2) values (123, abc);");
+            ExecuteInvalid("INSERT INTO test_json(c1, c2) values (123, 'abc');");
+            ExecuteInvalid("INSERT INTO test_json(c1, c2) values (123, 1);");
+            ExecuteInvalid("INSERT INTO test_json(c1, c2) values (123, 2.0);");
+            ExecuteInvalid("INSERT INTO test_json(c1, c2) values (123, null);");
+            ExecuteInvalid("INSERT INTO test_json(c1, c2) values (123, true);");
+            ExecuteInvalid("INSERT INTO test_json(c1, c2) values (123, false);");
+            ExecuteInvalid("INSERT INTO test_json(c1, c2) values (123, '{a:1, \"b\":2}');");
+
+            // Test operators.
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->'p' = " +
+                "'4294967295'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->>'p' = " +
+                "'4294967295'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->>'p' = " +
+                "'4294967295' AND c1 = 1"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c1 = 1 AND c2->'a'->'q'->>'p' " +
+                "= '4294967295'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a1'->5->'k2'->1 = '200'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a1'->5->'k3' = 'true'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a1'->0 = '1'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a2' = '{}'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a3' = '\"\"'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'e' = 'null'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'c' = 'false'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->>'f' = 'hello'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'f' = '\"hello\"'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->>'x' = '2.000000'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q' = " +
+                "'{\"r\": -2147483648, \"p\": 4294967295,  \"s\": 2147483647}'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->>'q' = " +
+                "'{\"p\":4294967295,\"r\":-2147483648,\"s\":2147483647}'"));
+
+            TestScalar("\"abc\"", 2);
+            TestScalar("3", 3);
+            TestScalar("true", 4);
+            TestScalar("false", 5);
+            TestScalar("null", 6);
+            TestScalar("2.0", 7);
+            Assert.AreEqual(2, _session.Execute("SELECT * FROM test_json WHERE c2->'b' = '1'")
+                .ToArray().Length);
+
+            // Test multiple where expressions.
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'g' = '-100' " +
+                "AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) = 2.0"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST (c2->'a'->>'g' as " +
+                "integer) < 0 AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) > 1.0"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST (c2->'a'->>'g' as " +
+                "integer) <= -100 AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) >= 2.0"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->>'g' as integer)" +
+                " IN (-100, -200) AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) IN (1.0, 2.0)"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->>'g' as integer)" +
+                " NOT IN (-10, -200) AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) IN (1.0, 2.0)"));
+
+            // Test negative where expressions.
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a'->'g' = '-90' " +
+                "AND c1 = 1").ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a'->'g' = '-90' " +
+                "AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) = 2.0").ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE CAST (c2->'a'->>'g' as " +
+                "integer) < 0 AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) < 1.0").ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE CAST (c2->'a'->>'g' as " +
+                "integer) <= -110 AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) >= 2.0").
+                ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->>'g' as integer)" +
+                " IN (-100, -200) AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) IN (1.0, 2.3)")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->>'g' as integer)" +
+                " IN (-100, -200) AND c2->'b' = '1' AND CAST(c2->'a'->>'x' as double) NOT IN (1.0, 2.0)")
+                .ToArray().Length);
+
+            // Test invalid where expressions.
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a'->'g' = '-100' AND c2 = '{}'");
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2 = '{} AND c2->'a'->'g' = '-100'");
+
+            // Test invalid operators. We should never return errors, just return an empty result (this
+            // is what postgres does).
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'b'->'c' = '1'")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'z' = '1'")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->2 = '1'")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a'->2 = '1'")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a1'->'b' = '1'")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a1'->6 = '1'")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a2'->'a' = '1'")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a3'->'a' = '1'")
+                .ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a3'->2 = '1'")
+                .ToArray().Length);
+
+            // Test invalid rhs for where clause.
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a1'->5->'k2'->1 = 200");
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a1'->5->'k3' = true");
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a1'->0 = 1");
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a2' = '{a:1}'");
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a3' = ''");
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a'->'e' = null");
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a'->'c' = false");
+            ExecuteInvalid("SELECT * FROM test_json WHERE c2->'a'->>'f' = hello");
+
+            // Test json operators in select clause.
+            Assert.AreEqual("4294967295",
+                _session.Execute(
+                    "SELECT c2->'a'->'q'->>'p' FROM test_json WHERE c1 = 1").First().GetValue<string>(0));
+            Assert.AreEqual("200",
+                _session.Execute(
+                    "SELECT c2->'a1'->5->'k2'->1 FROM test_json WHERE c1 = 1").First().GetValue<string>(0));
+            Assert.AreEqual("true",
+                _session.Execute(
+                    "SELECT c2->'a1'->5->'k3' FROM test_json WHERE c1 = 1").First().GetValue<string>(0));
+            Assert.AreEqual("2.000000",
+                _session.Execute(
+                    "SELECT c2->'a'->>'x' FROM test_json WHERE c1 = 1").First().GetValue<string>(0));
+            Assert.AreEqual("{\"p\":4294967295,\"r\":-2147483648,\"s\":2147483647}",
+                _session.Execute(
+                    "SELECT c2->'a'->'q' FROM test_json WHERE c1 = 1").First().GetValue<string>(0));
+            Assert.AreEqual("{\"p\":4294967295,\"r\":-2147483648,\"s\":2147483647}",
+                _session.Execute(
+                    "SELECT c2->'a'->>'q' FROM test_json WHERE c1 = 1").First().GetValue<string>(0));
+            Assert.AreEqual("\"abc\"",
+                _session.Execute(
+                    "SELECT c2 FROM test_json WHERE c1 = 2").First().GetValue<string>(0));
+            Assert.AreEqual("true",
+                _session.Execute(
+                    "SELECT c2 FROM test_json WHERE c1 = 4").First().GetValue<string>(0));
+            Assert.AreEqual("false",
+                _session.Execute(
+                    "SELECT c2 FROM test_json WHERE c1 = 5").First().GetValue<string>(0));
+
+            // Json operators in both select and where clause.
+            Assert.AreEqual("4294967295",
+                _session.Execute(
+                    "SELECT c2->'a'->'q'->>'p' FROM test_json WHERE c2->'a1'->5->'k2'->1 = '200'").First().GetValue<string>(0));
+            Assert.AreEqual("{\"p\":4294967295,\"r\":-2147483648,\"s\":2147483647}",
+                _session.Execute(
+                    "SELECT c2->'a'->'q' FROM test_json WHERE c2->'a1'->5->'k3' = 'true'").First().GetValue<string>(0));
+
+            Assert.AreEqual("{\"p\":4294967295,\"r\":-2147483648,\"s\":2147483647}",
+                _session.Execute(
+                    "SELECT c2->'a'->'q' FROM test_json WHERE c2->'a1'->5->'k3' = 'true'").First().GetValue<string>("expr"));
+
+            // Test select with invalid operators, which should result in empty rows.
+            VerifyNullRows(_session.Execute("SELECT c2->'b'->'c' FROM test_json WHERE c1 = 1"), 1);
+            VerifyNullRows(_session.Execute("SELECT c2->'z' FROM test_json"), 8);
+            VerifyNullRows(_session.Execute("SELECT c2->2 FROM test_json"), 8);
+            VerifyNullRows(_session.Execute("SELECT c2->'a'->2 FROM test_json"), 8);
+            VerifyNullRows(_session.Execute("SELECT c2->'a1'->'b' FROM test_json"), 8);
+            VerifyNullRows(_session.Execute("SELECT c2->'a1'->6 FROM test_json"), 8);
+            VerifyNullRows(_session.Execute("SELECT c2->'a1'->'a' FROM test_json"), 8);
+            VerifyNullRows(_session.Execute("SELECT c2->'a3'->'a' FROM test_json"), 8);
+            VerifyNullRows(_session.Execute("SELECT c2->'a3'->2 FROM test_json"), 8);
+
+            // Test casts.
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) = 4294967295"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "text) = '4294967295'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'r' as " +
+                "integer) = -2147483648"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'r' as " +
+                "text) = '-2147483648'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'s' as " +
+                "integer) = 2147483647"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a1'->5->'k2'->>1 as " +
+                "integer) = 200"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->>'x' as float) =" +
+                " 2.0"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->>'x' as double) " +
+                "= 2.0"));
+
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) >= 4294967295"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) > 100"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) <= 4294967295"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) < 4294967297"));
+
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) >= 4294967297").ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) > 4294967298").ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) = 100").ToArray().Length);
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as " +
+                "bigint) < 99").ToArray().Length);
+
+            // Invalid cast types.
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as boolean) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as inet) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as map) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as set) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as list) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as timestamp) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as timeuuid) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as uuid) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as varint) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->>'p' as decimal) = 123");
+            ExecuteInvalid("SELECT * FROM test_json WHERE CAST(c2->'a'->'q'->'p' as text) = '123'");
+
+            // Test update.
+            _session.Execute("UPDATE test_json SET c2->'a'->'q'->'p' = '100' WHERE c1 = 1");
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->'p' = " +
+                "'100'"));
+            _session.Execute("UPDATE test_json SET c2->'a'->'q'->'p' = '\"100\"' WHERE c1 = 1 IF " +
+                "c2->'a'->'q'->'s' = '2147483647' AND c2->'a'->'q'->'r' = '-2147483648'");
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->'p' = " +
+                "'\"100\"'"));
+            _session.Execute("UPDATE test_json SET c2->'a1'->5->'k2'->2 = '2000' WHERE c1 = 1");
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a1'->5->'k2'->2 = " +
+                "'2000'"));
+            _session.Execute("UPDATE test_json SET c2->'a2' = '{\"x1\": 1, \"x2\": 2, \"x3\": 3}' WHERE c1" +
+                " = 1");
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a2' = " +
+                "'{\"x1\": 1, \"x2\": 2, \"x3\": 3}'"));
+            _session.Execute("UPDATE test_json SET c2->'a'->'e' = '{\"y1\": 1, \"y2\": {\"z1\" : 1}}' " +
+                "WHERE c1 = 1");
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'e' = " +
+                "'{\"y1\": 1, \"y2\": {\"z1\" : 1}}'"));
+
+            // Test updates that don't apply.
+            _session.Execute("UPDATE test_json SET c2->'a'->'q'->'p' = '\"200\"' WHERE c1 = 1 IF " +
+                "c2->'a'->'q'->'s' = '2' AND c2->'a'->'q'->'r' = '-2147483648'");
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->'p' = " +
+                "'\"200\"'").ToArray().Length);
+
+            // Invalid updates.
+            // Invalid rhs (needs to be valid json)
+            ExecuteInvalid("UPDATE test_json SET c2->'a'->'q'->'p' = 100 WHERE c1 = 1");
+            // non-existent key.
+            ExecuteInvalid("UPDATE test_json SET c2->'a'->'q'->'xyz' = '100' WHERE c1 = 1");
+            ExecuteInvalid("UPDATE test_json SET c2->'aa'->'q'->'p' = '100' WHERE c1 = 1");
+            // Array out of bounds.
+            ExecuteInvalid("UPDATE test_json SET c2->'a1'->200->'k2'->2 = '2000' WHERE c1 = 1");
+            ExecuteInvalid("UPDATE test_json SET c2->'a1'->-2->'k2'->2 = '2000' WHERE c1 = 1");
+            ExecuteInvalid("UPDATE test_json SET c2->'a1'->5->'k2'->100 = '2000' WHERE c1 = 1");
+            ExecuteInvalid("UPDATE test_json SET c2->'a1'->5->'k2'->-1 = '2000' WHERE c1 = 1");
+            // Mixup arrays and objects.
+            ExecuteInvalid("UPDATE test_json SET c2->'a'->'q'->1 = '100' WHERE c1 = 1");
+            ExecuteInvalid("UPDATE test_json SET c2->'a1'->5->'k2'->'abc' = '2000' WHERE c1 = 1");
+            ExecuteInvalid("UPDATE test_json SET c2->5->'q'->'p' = '100' WHERE c1 = 1");
+            ExecuteInvalid("UPDATE test_json SET c2->'a1'->'b'->'k2'->2 = '2000' WHERE c1 = 1");
+            // Invalid RHS.
+            ExecuteInvalid("UPDATE test_json SET c2->'a'->'q'->'p' = c1->'a' WHERE c1 = 1");
+            ExecuteInvalid("UPDATE test_json SET c2->'a'->'q'->>'p' = c2->>'b' WHERE c1 = 1");
+
+
+            // Update the same column multiple times.
+            _session.Execute("UPDATE test_json SET c2->'a'->'q'->'r' = '200', c2->'a'->'x' = '2', " +
+                "c2->'a'->'l' = '3.0' WHERE c1 = 1");
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->'r' = '200'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'x' = '2'"));
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'l' = '3.0'"));
+
+            // Can't set entire column and nested attributes at the same time.
+            ExecuteInvalid("UPDATE test_json SET c2->'a'->'q'->'r' = '200', c2 = '{a : 1, b: 2}' WHERE c1" +
+                " = 1");
+            // Subscript args with json not allowed.
+            ExecuteInvalid("UPDATE test_json SET c2->'a'->'q'->'r' = '200', c2[0] = '1' WHERE c1 = 1");
+
+            // Test delete with conditions.
+            // Test deletes that don't apply.
+            _session.Execute("DELETE FROM test_json WHERE c1 = 1 IF " +
+                "c2->'a'->'q'->'s' = '200' AND c2->'a'->'q'->'r' = '-2147483648'");
+            VerifyRowSet(_session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->'p' = " +
+                "'\"100\"'"));
+
+            // Test delete that applies.
+            _session.Execute("DELETE FROM test_json WHERE c1 = 1 IF " +
+                "c2->'a'->'q'->'s' = '2147483647' AND c2->'a'->'q'->'r' = '200'");
+            Assert.AreEqual(0, _session.Execute("SELECT * FROM test_json WHERE c2->'a'->'q'->'p' = " +
+                "'\"100\"'").ToArray().Length);
+        }
+
+        private void VerifyRowSet(RowSet rs)
+        {
+            var rows = rs.ToArray();
+            Assert.AreEqual(1, rows.Length);
+            Row row = rows[0];
+            var jsonObject = JObject.Parse(row.GetValue<string>("c2"));
+            Assert.AreEqual(1, jsonObject.GetValue<int>("b"));
+            var a1 = jsonObject.GetArray("a1");
+            Assert.False(a1[3].Value<bool>());
+            Assert.AreEqual(3.0, a1[2].Value<double>(), 1e-9);
+            Assert.AreEqual(200, a1[5].Value<JObject>().GetArray("k2")[1].Value<int>());
+            var a = jsonObject.GetObject("a");
+            Assert.AreEqual(2147483647, a.GetObject("q").GetValue<int>("s"));
+            Assert.AreEqual("hello", a.GetValue<string>("f"));
+        }
+
+        private void ExecuteInvalid(string query)
+        {
+            try
+            {
+                _session.Execute(query);
+                Assert.Fail("Statement did not fail: {0}", query);
+            }
+            catch (QueryValidationException qv)
+            {
+                Trace.TraceInformation("Expected exception", qv);
+            }
+        }
+
+        private void TestScalar(string json, int c1)
+        {
+            Row row = _session.Execute(_session.Prepare("SELECT * FROM test_json WHERE c2 = ?").Bind(json)).First();
+            Assert.AreEqual(c1, row.GetValue<int>("c1"));
+            Assert.AreEqual(json, row.GetValue<string>("c2"));
+        }
+
+        private void VerifyNullRows(RowSet rs, int expected_rows)
+        {
+            var rows = rs.ToArray();
+            Assert.AreEqual(expected_rows, rows.Length);
+            foreach (var row in rows)
+            {
+                Assert.True(row.IsNull(0));
+            }
+        }
+    }
+}

--- a/src/Cassandra.YugaByte.Tests/JsonTest.cs
+++ b/src/Cassandra.YugaByte.Tests/JsonTest.cs
@@ -1,4 +1,17 @@
-﻿using System;
+﻿// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
 using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;

--- a/src/Cassandra.YugaByte.Tests/PolicyTest.cs
+++ b/src/Cassandra.YugaByte.Tests/PolicyTest.cs
@@ -1,3 +1,16 @@
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
 using System;
 using System.Diagnostics;
 using System.Net;

--- a/src/Cassandra.YugaByte.Tests/PolicyTest.cs
+++ b/src/Cassandra.YugaByte.Tests/PolicyTest.cs
@@ -1,0 +1,410 @@
+using System;
+using System.Diagnostics;
+using System.Net;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+
+namespace Cassandra.YugaByte.Tests
+{
+    [TestFixture]
+    public class PolicyTest
+    {
+        const int TotalKeys = 100;
+
+        delegate object CreateKey(int index);
+
+        private ICluster _cluster;
+        private ISession _session;
+
+        [OneTimeSetUp]
+        public void OneTimeSetUp()
+        {
+            Diagnostics.CassandraTraceSwitch.Level = TraceLevel.Verbose;
+            var ip = Environment.GetEnvironmentVariable("YB_CLUSTER_ADDRESS");
+            _cluster = Cluster.Builder().AddContactPoint(ip).Build();
+            _session = _cluster.Connect();
+            _session.Execute("CREATE KEYSPACE IF NOT EXISTS store");
+            _session.Execute("USE store");
+        }
+
+        [Test]
+        public void TimeHashKey()
+        {
+            TestPrimitive("time", i => new LocalTime(i * 57809));
+        }
+
+        [Test]
+        public void DateHashKey()
+        {
+            TestPrimitive("date", i => new LocalDate(1900 * i, 1 + i % 12, 1 + i % 28));
+        }
+
+        [Test]
+        public void InetHashKey()
+        {
+            TestPrimitive("inet", i => IPAddress.Parse(string.Format("{0}.1.{0}.2", i)));
+        }
+
+        [Test]
+        public void TimeUuidHashKey()
+        {
+            TestPrimitive("timeuuid", CreateTimeUuidByIndex);
+        }
+
+        [Test]
+        public void UuidHashKey()
+        {
+            TestPrimitive("uuid", CreateGuidByIndex);
+        }
+
+        [Test]
+        public void TimestampHashKey()
+        {
+            TestPrimitive("timestamp", i => CreateTimestampByIndex(i));
+        }
+
+        [Test]
+        public void FloatHashKey()
+        {
+            TestPrimitive("float", i => i == 0 ? float.NaN : (float)i / 3);
+        }
+
+        [Test]
+        public void DoubleHashKey()
+        {
+            TestPrimitive("double", i => i == 0 ? double.NaN : (double)i / 3);
+        }
+
+        [Test]
+        public void BlobHashKey()
+        {
+            TestPrimitive("blob", i => BitConverter.GetBytes(i));
+        }
+
+        [Test]
+        public void TextHashKey()
+        {
+            TestPrimitive("text", i => "key_" + i);
+        }
+
+        [Test]
+        public void TinyintHashKey()
+        {
+            TestPrimitive("tinyint", i => (sbyte)i);
+        }
+
+        [Test]
+        public void SmallintHashKey()
+        {
+            TestPrimitive("smallint", i => (short)i);
+        }
+
+        [Test]
+        public void IntHashKey()
+        {
+            TestPrimitive("int", i => i);
+        }
+
+        [Test]
+        public void BigintHashKey()
+        {
+            TestPrimitive("bigint", i => (long)i);
+        }
+
+        [Test]
+        public void VarcharHashKey()
+        {
+            TestPrimitive("varchar", i => "key_" + i);
+        }
+
+        [Test]
+        public void BooleanHashKey()
+        {
+            TestPrimitive("boolean", i => (i & 1) != 0, 2);
+        }
+
+        [Test]
+        public void TextAndBlobHash()
+        {
+            TestToken(typeof(string), typeof(string), typeof(byte[]), typeof(string));
+        }
+
+        [Test]
+        public void IntAndTextHash()
+        {
+            TestToken(typeof(sbyte), typeof(short), typeof(string), typeof(int), typeof(long));
+        }
+
+        [Test]
+        public void MixedHash()
+        {
+            TestToken(typeof(int), typeof(DateTimeOffset), typeof(IPAddress), typeof(Guid), typeof(TimeUuid));
+        }
+
+        [Test]
+        public void FloatsHash()
+        {
+            TestToken(typeof(float), typeof(double));
+        }
+
+        [Test]
+        public void DateTimeHash()
+        {
+            TestToken(typeof(LocalDate), typeof(LocalTime));
+        }
+
+        [Test]
+        public void BoolHash()
+        {
+            TestToken(typeof(bool));
+        }
+
+        private void TestToken(params Type[] types)
+        {
+            var tableName = string.Join("_", types.Select(type => TestUtils.TypeToColumnType(type)));
+            _session.Execute(string.Format("DROP TABLE IF EXISTS {0}", tableName));
+            var columns = string.Join(", ", types.Select((type, idx) => string.Format("h{1} {0}", TestUtils.TypeToColumnType(type), idx)));
+            var primaryKey = string.Join(", ", types.Select((type, idx) => "h" + idx));
+            var questions = string.Join(", ", Enumerable.Repeat("?", types.Length));
+            _session.Execute(string.Format("CREATE TABLE IF NOT EXISTS {0} ({1}, PRIMARY KEY (({2})));", tableName, columns, primaryKey));
+
+            var rand = new Random();
+            var values = new object[types.Length];
+            for (var i = 0; i != types.Length; ++i)
+            {
+                values[i] = rand.RandomValue(types[i]);
+            }
+            var stmt = _session.Prepare(string.Format("INSERT INTO {0} ({1}) VALUES ({2})", tableName, primaryKey, questions)).Bind(values);
+            _session.Execute(stmt);
+
+            var token = PartitionAwarePolicy.YBHashCode(stmt);
+            Trace.TraceInformation("Token: {0}", token);
+            var bs = _session.Prepare(string.Format("SELECT * FROM {0} WHERE TOKEN({1}) = ?", tableName, primaryKey)).Bind(token);
+            var row = _session.Execute(bs).FirstOrDefault();
+            Assert.NotNull(row);
+            for (var i = 0; i != types.Length; ++i)
+            {
+                Assert.AreEqual(values[i], row.GetValue(types[i], "h" + i));
+            }
+
+            _session.Execute(string.Format("DROP TABLE {0}", tableName));
+        }
+
+        [Test]
+        public void DML()
+        {
+            _session.Execute("CREATE TABLE IF NOT EXISTS test_lb (h1 INT, h2 TEXT, c INT, PRIMARY KEY ((h1, h2)));");
+            _session.Cluster.Metadata.RefreshSchema();
+
+            var preMetrics = _cluster.FetchMetrics();
+            var ps = _session.Prepare("INSERT INTO test_lb (h1, h2, c) VALUES (?, ?, ?)");
+
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                _session.Execute(ps.Bind(i, "v" + i, i));
+            }
+
+            var deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Local inserts: {0}", deltaMetrics.localWrite);
+            Assert.Greater(deltaMetrics.localWrite * 10, TotalKeys * 7);
+            preMetrics += deltaMetrics;
+
+            ps = _session.Prepare("UPDATE test_lb SET c = ? WHERE h1 = ? AND h2 = ?");
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                _session.Execute(ps.Bind(i*2, i, "v" + i));
+            }
+
+            deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Local updates: {0}", deltaMetrics.localWrite);
+            Assert.Greater(deltaMetrics.localWrite * 10, TotalKeys * 7);
+            preMetrics += deltaMetrics;
+
+            ps = _session.Prepare("SELECT c FROM test_lb WHERE h1 = ? AND h2 = ?");
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                Row row = _session.Execute(ps.Bind(i, "v" + i)).FirstOrDefault();
+                Assert.NotNull(row);
+                Assert.AreEqual(i * 2, row.GetValue<int>("c"));
+            }
+
+            deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Local selects: {0}", deltaMetrics.localRead);
+            Assert.Greater(deltaMetrics.localRead * 10, TotalKeys * 7);
+            preMetrics += deltaMetrics;
+
+            ps = _session.Prepare("DELETE FROM test_lb WHERE h1 = ? AND h2 = ?");
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                _session.Execute(ps.Bind(i, "v" + i));
+            }
+
+            deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Local deletes: {0}", deltaMetrics.localWrite);
+            Assert.Greater(deltaMetrics.localWrite * 10, TotalKeys * 7);
+
+            _session.Execute("DROP TABLE test_lb");
+        }
+
+        [Test]
+        public void Index()
+        {
+            _session.Execute("DROP TABLE IF EXISTS test_lb_idx");
+            _session.Execute("CREATE TABLE test_lb_idx (h1 INT, h2 TEXT, c INT, PRIMARY KEY ((h1, h2))) " +
+                             "WITH TRANSACTIONS = { 'enabled' : true };");
+            _session.Execute("CREATE INDEX test_lb_idx_1 ON test_lb_idx (h1) INCLUDE (c);");
+            _session.Execute("CREATE INDEX test_lb_idx_2 ON test_lb_idx (c);");
+            _session.Cluster.Metadata.RefreshSchema();
+
+            var preMetrics = _cluster.FetchMetrics();
+            var ps = _session.Prepare("INSERT INTO test_lb_idx (h1, h2, c) VALUES (?, ?, ?)");
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                _session.Execute(ps.Bind(i, "v" + i, i));
+            }
+
+            var deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Local inserts: {0}", deltaMetrics.localWrite);
+            Assert.Greater(deltaMetrics.localWrite * 10, TotalKeys * 7);
+            preMetrics += deltaMetrics;
+
+            ps = _session.Prepare("SELECT c FROM test_lb_idx WHERE h1 = ?");
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                Row row = _session.Execute(ps.Bind(i)).FirstOrDefault();
+                Assert.NotNull(row);
+                Assert.AreEqual(i, row.GetValue<int>("c"));
+            }
+
+            deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Selects, local: {0}, remote: {1}", deltaMetrics.localRead, deltaMetrics.remoteRead);
+            Assert.Greater(deltaMetrics.localRead * 10, TotalKeys * 7);
+            preMetrics += deltaMetrics;
+
+            ps = _session.Prepare("SELECT h1, h2 FROM test_lb_idx WHERE c = ?");
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                Row row = _session.Execute(ps.Bind(i)).FirstOrDefault();
+                Assert.NotNull(row);
+                Assert.AreEqual(i, row.GetValue<int>("h1"));
+                Assert.AreEqual("v" + i, row.GetValue<string>("h2"));
+            }
+
+            deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Selects, local: {0}, remote: {1}", deltaMetrics.localRead, deltaMetrics.remoteRead);
+            Assert.Greater(deltaMetrics.localRead * 10, TotalKeys * 7);
+
+            _session.Execute("DROP TABLE test_lb_idx");
+        }
+
+        [Test]
+        public void BatchStatement()
+        {
+            // Create test table.
+            _session.Execute("CREATE TABLE IF NOT EXISTS test_lb (h INT, r TEXT, c INT, PRIMARY KEY ((h), r))");
+            _session.Cluster.Metadata.RefreshSchema();
+
+            var preMetrics = _cluster.FetchMetrics();
+            var ps = _session.Prepare("INSERT INTO test_lb (h, r, c) VALUES (?, ?, ?)");
+
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                BatchStatement batch = new BatchStatement();
+                for (int j = 1; j <= 5; j++)
+                {
+                 batch.Add(ps.Bind(i, "v" + j, i * j));
+                }
+                _session.Execute(batch);
+            }
+
+            var deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Inserts, local: {0}, remote: {1}", deltaMetrics.localWrite, deltaMetrics.remoteWrite);
+            Assert.Greater(deltaMetrics.localWrite * 10, TotalKeys * 7);
+            preMetrics += deltaMetrics;
+
+            ps = _session.Prepare("SELECT c FROM test_lb WHERE h = ? and r = 'v3'");
+            for (int i = 1; i <= TotalKeys; ++i)
+            {
+                Row row = _session.Execute(ps.Bind(i)).FirstOrDefault();
+                Assert.NotNull(row);
+                Assert.AreEqual(i * 3, row.GetValue<int>("c"));
+            }
+
+            deltaMetrics = _cluster.FetchMetrics() - preMetrics;
+            Trace.TraceInformation("Selects, local: {0}, remote: {1}", deltaMetrics.localRead, deltaMetrics.remoteRead);
+            Assert.Greater(deltaMetrics.localRead * 10, TotalKeys * 7);
+
+            _session.Execute("DROP TABLE test_lb");
+        }
+
+        private void TestPrimitive(string type, CreateKey createKey, int totalKeys = TotalKeys)
+        {
+            Trace.TraceInformation("Testing {0}, keys: {1}", type, totalKeys);
+            var preMetrics = _cluster.FetchMetrics();
+            TestPartition(type, createKey, totalKeys);
+            var postMetrics = _cluster.FetchMetrics();
+            var localReads = postMetrics.localRead - preMetrics.localRead;
+            var localWrites = postMetrics.localWrite - preMetrics.localWrite;
+            var oldColor = Console.ForegroundColor;
+            Trace.TraceInformation("Local reads = {0}, local writes = {1}", localReads, localWrites);
+            Trace.TraceInformation("Remote reads = {0}, remote writes = {1}", postMetrics.remoteRead - preMetrics.remoteRead, postMetrics.remoteWrite - preMetrics.remoteWrite);
+            Assert.Greater(localReads * 10, totalKeys * 7);
+            Assert.Greater(localWrites * 10, totalKeys * 7);
+        }
+
+        private void TestPartition(string type, CreateKey createKey, int totalKeys)
+        {
+            var tableName = "simple_" + type;
+            _session.Execute(string.Format("CREATE TABLE IF NOT EXISTS {0}(id {1} PRIMARY KEY, data varchar)", tableName, type));
+            _session.Cluster.Metadata.RefreshSchema();
+            Trace.TraceInformation("Created table {0}", tableName);
+            var ps = _session.Prepare(string.Format("INSERT INTO {0} (id, data) VALUES (?, ?)", tableName));
+
+            for (int i = 0; i != totalKeys; ++i)
+            {
+                _session.Execute(ps.Bind(createKey(i), CreateData(i)));
+            }
+
+            ps = _session.Prepare(string.Format("SELECT data FROM {0} WHERE id = ?", tableName));
+
+            for (int i = 0; i != totalKeys; ++i)
+            {
+                var rs = _session.Execute(ps.Bind(createKey(i)));
+                var count = 0;
+                foreach (var row in rs)
+                {
+                    var data = row.GetValue<string>("data");
+                    Assert.AreEqual(data, CreateData(i));
+                    ++count;
+                }
+                Assert.AreEqual(count, 1);
+            }
+            _session.Execute(string.Format("DROP TABLE {0}", tableName));
+        }
+
+        private string CreateData(int index)
+        {
+            return "data_" + index;
+        }
+
+        private object CreateGuidByIndex(int i)
+        {
+            byte b = (byte)i;
+            return new Guid(i, (short)i, (short)i, (byte)(i + 1), (byte)(i + 2), (byte)(i + 3), (byte)(i + 4), (byte)(i + 5), (byte)(i + 6), (byte)(i + 7), (byte)(i + 8));
+        }
+
+        private object CreateTimeUuidByIndex(int i)
+        {
+            var b = (byte)i;
+            var nodeId = new byte[6] { b, b, b, b, b, b };
+            var clockId = new byte[2] { b, b };
+            return TimeUuid.NewId(nodeId, clockId, CreateTimestampByIndex(i));
+        }
+
+        private DateTimeOffset CreateTimestampByIndex(int i)
+        {
+            return new DateTimeOffset(2018 + i, 1, 1, i % 24, 0, i % 60, 0, TimeSpan.Zero).AddTicks(i * 997);
+        }
+    }
+}

--- a/src/Cassandra.YugaByte.Tests/TestUtils.cs
+++ b/src/Cassandra.YugaByte.Tests/TestUtils.cs
@@ -269,5 +269,20 @@ namespace Cassandra.YugaByte.Tests
         {
             return prefix + type.Replace('<', '_').Replace(">", "").Replace(',', '_').Replace(" ", "").Replace("frozen_", "");
         }
+
+        public static JArray GetArray(this JObject obj, string name)
+        {
+            return (JArray)obj.GetValue(name);
+        }
+
+        public static JObject GetObject(this JObject obj, string name)
+        {
+            return (JObject)obj.GetValue(name);
+        }
+
+        public static T GetValue<T>(this JObject obj, string name)
+        {
+            return obj.GetValue(name).Value<T>();
+        }
     }
 }

--- a/src/Cassandra.YugaByte.Tests/TestUtils.cs
+++ b/src/Cassandra.YugaByte.Tests/TestUtils.cs
@@ -1,0 +1,198 @@
+﻿using Newtonsoft.Json.Linq;
+using System;
+using System.Net;
+using System.Text;
+using System.Collections.Generic;
+
+namespace Cassandra.YugaByte.Tests
+{
+    public struct IOMetrics
+    {
+        public long localRead;
+        public long localWrite;
+        public long remoteRead;
+        public long remoteWrite;
+
+        public static IOMetrics operator -(IOMetrics lhs, IOMetrics rhs)
+        {
+            lhs.localRead -= rhs.localRead;
+            lhs.localWrite -= rhs.localWrite;
+            lhs.remoteRead -= rhs.remoteRead;
+            lhs.remoteWrite -= rhs.remoteWrite;
+            return lhs;
+        }
+
+        public static IOMetrics operator +(IOMetrics lhs, IOMetrics rhs)
+        {
+            lhs.localRead += rhs.localRead;
+            lhs.localWrite += rhs.localWrite;
+            lhs.remoteRead += rhs.remoteRead;
+            lhs.remoteWrite += rhs.remoteWrite;
+            return lhs;
+        }
+    }
+
+    public static class TestUtils
+    {
+        const string MetricPrefix = "handler_latency_yb_client_";
+
+        public static IOMetrics FetchMetrics(this ICluster cluster)
+        {
+            IOMetrics result = new IOMetrics();
+            using (var client = new WebClient())
+            {
+                foreach (var host in cluster.AllHosts())
+                {
+                    var url = string.Format("http://{0}:{1}/metrics", host.Address.Address, 8888);
+                    var response = client.DownloadString(url);
+                    var json = JArray.Parse(response);
+                    foreach (var child in json.Children())
+                    {
+                        if (child["type"].ToString() == "server")
+                        {
+                            foreach (var metric in child["metrics"].Children())
+                            {
+                                var name = metric["name"].ToString();
+                                if (name.StartsWith(MetricPrefix))
+                                {
+                                    var suffix = name.Substring(MetricPrefix.Length);
+                                    var value = metric["total_count"].ToObject<long>();
+                                    if (suffix == "write_local")
+                                    {
+                                        result.localWrite += value;
+                                    }
+                                    else if (suffix == "read_local")
+                                    {
+                                        result.localRead += value;
+                                    }
+                                    else if (suffix == "write_remote")
+                                    {
+                                        result.remoteWrite += value;
+                                    }
+                                    else if (suffix == "read_remote")
+                                    {
+                                        result.remoteRead += value;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            return result;
+        }
+
+        public static string RandomString(this Random rand, int len)
+        {
+            var bytes = new byte[len];
+            for (int i = 0; i != len; ++i)
+            {
+                bytes[i] = (byte)rand.Next(32, 127);
+            }
+            return Encoding.ASCII.GetString(bytes);
+        }
+
+        public static byte[] RandomBytes(this Random rand, int len)
+        {
+            var bytes = new byte[len];
+            rand.NextBytes(bytes);
+            return bytes;
+        }
+
+        public static long NextLong(this Random rand)
+        {
+            return BitConverter.ToInt64(rand.RandomBytes(8), 0);
+        }
+
+        public static long NextLong(this Random rand, long min, long max)
+        {
+            if (min == long.MinValue && max == long.MaxValue)
+            {
+                return rand.NextLong();
+            }
+            ulong delta = (ulong)(max - min + 1);
+            return min + (long)((ulong)rand.NextLong() % delta);
+        }
+
+        public static IPAddress RandomIPAddress(this Random rand)
+        {
+            return new IPAddress(rand.RandomBytes(4));
+        }
+
+        public static Guid RandomGuid(this Random rand)
+        {
+            return new Guid(rand.RandomBytes(16));
+        }
+
+        public static DateTimeOffset RandomDateTimeOffset(this Random rand)
+        {
+            // Trim up to milliseconds
+            return new DateTimeOffset(rand.NextLong(DateTime.MinValue.Ticks, DateTime.MaxValue.Ticks) / 1000000 * 1000000, TimeSpan.Zero);
+        }
+
+        public static TimeUuid RandomTimeUuid(this Random rand)
+        {
+            return TimeUuid.NewId(rand.RandomBytes(6), rand.RandomBytes(2), rand.RandomDateTimeOffset());
+        }
+
+        private delegate object RandomValueImpl(Random rand);
+
+        private static IDictionary<Type, RandomValueImpl> _randomValueGenerators = new Dictionary<Type, RandomValueImpl>()
+        {
+            { typeof(string), rand => rand.RandomString(rand.Next(256)) },
+            { typeof(byte[]), rand => rand.RandomBytes(rand.Next(256)) },
+            { typeof(sbyte), rand => (sbyte)rand.Next(sbyte.MinValue, sbyte.MaxValue) },
+            { typeof(short), rand => (short)rand.Next(short.MinValue, short.MaxValue) },
+            { typeof(int), rand => rand.Next() },
+            { typeof(long), rand => rand.NextLong() },
+            { typeof(DateTimeOffset), rand => rand.RandomDateTimeOffset() },
+            { typeof(IPAddress), rand => rand.RandomIPAddress() },
+            { typeof(Guid), rand => rand.RandomGuid() },
+            { typeof(TimeUuid), rand => rand.RandomTimeUuid() },
+            { typeof(bool), rand => (rand.Next() & 1) != 0 },
+            { typeof(float), rand => (float)rand.NextDouble() },
+            { typeof(double), rand => rand.NextDouble() },
+            { typeof(LocalDate), rand => new LocalDate((uint)rand.Next()) },
+            { typeof(LocalTime), rand => new LocalTime(rand.NextLong(0, 86399999999999L)) },
+        };
+
+        private static IDictionary<Type, string> _typeToColumnType = new Dictionary<Type, string>()
+        {
+            { typeof(string), "TEXT" },
+            { typeof(byte[]), "BLOB" },
+            { typeof(sbyte), "TINYINT" },
+            { typeof(short), "SMALLINT" },
+            { typeof(int), "INT" },
+            { typeof(long), "BIGINT" },
+            { typeof(DateTimeOffset), "TIMESTAMP" },
+            { typeof(IPAddress), "INET" },
+            { typeof(Guid), "UUID" },
+            { typeof(TimeUuid), "TIMEUUID" },
+            { typeof(bool), "BOOLEAN" },
+            { typeof(float), "FLOAT" },
+            { typeof(double), "DOUBLE" },
+            { typeof(LocalDate), "DATE" },
+            { typeof(LocalTime), "TIME" },
+        };
+
+        public static object RandomValue(this Random rand, Type type)
+        {
+            RandomValueImpl impl;
+            if (!_randomValueGenerators.TryGetValue(type, out impl))
+            {
+                throw new ArgumentException("Cannot generate value for type: " + type);
+            }
+            return impl(rand);
+        }
+
+        public static string TypeToColumnType(Type type)
+        {
+            string result;
+            if (!_typeToColumnType.TryGetValue(type, out result))
+            {
+                throw new ArgumentException("Cannot convert type to column type: " + type);
+            }
+            return result;
+        }
+    }
+}

--- a/src/Cassandra.YugaByte.Tests/TestUtils.cs
+++ b/src/Cassandra.YugaByte.Tests/TestUtils.cs
@@ -1,4 +1,17 @@
-﻿using Newtonsoft.Json.Linq;
+﻿// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+using Newtonsoft.Json.Linq;
 using System;
 using System.Net;
 using System.Text;

--- a/src/Cassandra.YugaByte.Tests/TestUtils.cs
+++ b/src/Cassandra.YugaByte.Tests/TestUtils.cs
@@ -150,6 +150,21 @@ namespace Cassandra.YugaByte.Tests
             return TimeUuid.NewId(rand.RandomBytes(6), rand.RandomBytes(2), rand.RandomDateTimeOffset());
         }
 
+        public static float RandomFloatNan(this Random rand)
+        {
+            var bytes = BitConverter.GetBytes(float.NaN);
+            bytes[1] = (byte)rand.Next(255);
+            var v = BitConverter.ToSingle(bytes, 0);
+            return v;
+        }
+
+        public static double RandomDoubleNan(this Random rand)
+        {
+            var v = BitConverter.DoubleToInt64Bits(double.NaN);
+            v ^= (long)rand.Next() << 16;
+            return BitConverter.Int64BitsToDouble(v);
+        }
+
         private delegate object RandomValueImpl(Random rand);
 
         private static IDictionary<Type, RandomValueImpl> _randomValueGenerators = new Dictionary<Type, RandomValueImpl>()
@@ -165,8 +180,8 @@ namespace Cassandra.YugaByte.Tests
             { typeof(Guid), rand => rand.RandomGuid() },
             { typeof(TimeUuid), rand => rand.RandomTimeUuid() },
             { typeof(bool), rand => (rand.Next() & 1) != 0 },
-            { typeof(float), rand => (float)rand.NextDouble() },
-            { typeof(double), rand => rand.NextDouble() },
+            { typeof(float), rand => (rand.Next() & 15) != 0 ? rand.RandomFloatNan() : (float)rand.NextDouble() },
+            { typeof(double), rand => (rand.Next() & 15) != 0 ? rand.RandomDoubleNan() : rand.NextDouble() },
             { typeof(LocalDate), rand => new LocalDate((uint)rand.Next()) },
             { typeof(LocalTime), rand => new LocalTime(rand.NextLong(0, 86399999999999L)) },
             { typeof(UDT), rand => new UDT(rand.Next(), rand.RandomString(rand.Next(256)), (float)rand.NextDouble()) },

--- a/src/Cassandra.sln
+++ b/src/Cassandra.sln
@@ -9,6 +9,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cassandra.Tests", "Cassandr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Cassandra.IntegrationTests", "Cassandra.IntegrationTests\Cassandra.IntegrationTests.csproj", "{6E9E4BBB-7FFD-4337-8639-6F52DCACD591}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cassandra.YugaByte.Tests", "Cassandra.YugaByte.Tests\Cassandra.YugaByte.Tests.csproj", "{E6B3676D-4F0B-4033-99F7-3D678C5F2B84}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,8 +29,15 @@ Global
 		{6E9E4BBB-7FFD-4337-8639-6F52DCACD591}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6E9E4BBB-7FFD-4337-8639-6F52DCACD591}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6E9E4BBB-7FFD-4337-8639-6F52DCACD591}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E6B3676D-4F0B-4033-99F7-3D678C5F2B84}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E6B3676D-4F0B-4033-99F7-3D678C5F2B84}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E6B3676D-4F0B-4033-99F7-3D678C5F2B84}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E6B3676D-4F0B-4033-99F7-3D678C5F2B84}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {0C0DEA39-E5F3-4A52-9A69-38D8BE0C7F2C}
 	EndGlobalSection
 EndGlobal

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Cassandra/Cluster.cs
+++ b/src/Cassandra/Cluster.cs
@@ -53,6 +53,12 @@ namespace Cassandra
         /// <inheritdoc />
         public event Action<Host> HostRemoved;
 
+        internal Serializer Serializer { get
+            {
+                return _serializer;
+            }
+        }
+
         /// <summary>
         /// Gets the control connection used by the cluster
         /// </summary>

--- a/src/Cassandra/ConsistencyLevel.cs
+++ b/src/Cassandra/ConsistencyLevel.cs
@@ -77,8 +77,8 @@ namespace Cassandra
         /// Similar to <c>One</c> but only within the DC the coordinator is in.
         /// </summary>
         LocalOne = 0x000A,
-        YbConsistentPrefix = One,
-        YbStrong = Quorum,
+        YBConsistentPrefix = One,
+        YBStrong = Quorum,
     }
 
     public static class ConsistencyLevelMethod
@@ -86,9 +86,9 @@ namespace Cassandra
         /// <summary>
         /// Whether or not this consistency level corresponds to YB strong consistency.
         /// </summary> 
-        public static bool IsStrong(this ConsistencyLevel self)
+        public static bool IsStrong(this ConsistencyLevel level)
         {
-            return self == ConsistencyLevel.Quorum || self == ConsistencyLevel.LocalOne;
+            return level == ConsistencyLevel.Quorum || level == ConsistencyLevel.LocalOne;
         }
     }
 }

--- a/src/Cassandra/ConsistencyLevel.cs
+++ b/src/Cassandra/ConsistencyLevel.cs
@@ -76,6 +76,19 @@ namespace Cassandra
         /// <summary>
         /// Similar to <c>One</c> but only within the DC the coordinator is in.
         /// </summary>
-        LocalOne = 0x000A
+        LocalOne = 0x000A,
+        YbConsistentPrefix = One,
+        YbStrong = Quorum,
+    }
+
+    public static class ConsistencyLevelMethod
+    {
+        /// <summary>
+        /// Whether or not this consistency level corresponds to YB strong consistency.
+        /// </summary> 
+        public static bool IsStrong(this ConsistencyLevel self)
+        {
+            return self == ConsistencyLevel.Quorum || self == ConsistencyLevel.LocalOne;
+        }
     }
 }

--- a/src/Cassandra/ConsistencyLevel.cs
+++ b/src/Cassandra/ConsistencyLevel.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 namespace Cassandra
 {

--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Linq;

--- a/src/Cassandra/ControlConnection.cs
+++ b/src/Cassandra/ControlConnection.cs
@@ -25,6 +25,7 @@ using Cassandra.Tasks;
 using Cassandra.Requests;
 using Cassandra.Responses;
 using Cassandra.Serialization;
+using Cassandra.YugaByte;
 
 namespace Cassandra
 {
@@ -132,6 +133,7 @@ namespace Cassandra
                     _host = host;
 
                     await RefreshNodeList().ConfigureAwait(false);
+                    await _metadata.RefreshPartitionMap().ConfigureAwait(false);
 
                     var commonVersion = ProtocolVersion.GetHighestCommon(_metadata.Hosts);
                     if (commonVersion != _serializer.ProtocolVersion)
@@ -265,6 +267,7 @@ namespace Cassandra
             try
             {
                 await RefreshNodeList().ConfigureAwait(false);
+                await _metadata.RefreshPartitionMap().ConfigureAwait(false);
                 await _metadata.RefreshKeyspaces().ConfigureAwait(false);
                 _reconnectionSchedule = _reconnectionPolicy.NewSchedule();
             }

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections.Concurrent;

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -23,6 +23,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Cassandra.Requests;
 using Cassandra.Tasks;
+using Cassandra.YugaByte;
 
 namespace Cassandra
 {
@@ -34,6 +35,7 @@ namespace Cassandra
     {
         private const string SelectSchemaVersionPeers = "SELECT schema_version FROM system.peers";
         private const string SelectSchemaVersionLocal = "SELECT schema_version FROM system.local";
+        private const string SelectPartitions = "SELECT keyspace_name, table_name, start_key, end_key, replica_addresses FROM system.partitions";
         private static readonly Logger Logger = new Logger(typeof(ControlConnection));
         private volatile TokenMap _tokenMap;
         private volatile ConcurrentDictionary<string, KeyspaceMetadata> _keyspaces = new ConcurrentDictionary<string,KeyspaceMetadata>();
@@ -62,6 +64,8 @@ namespace Cassandra
         internal string Partitioner { get; set; }
 
         internal Hosts Hosts { get; private set; }
+
+        public IDictionary<string, TableSplitMetadata> TableSplitMetadata { get; private set; }
 
         internal Metadata(Configuration configuration)
         {
@@ -313,6 +317,7 @@ namespace Cassandra
         /// </summary>
         public bool RefreshSchema(string keyspace = null, string table = null)
         {
+            TaskHelper.WaitToComplete(RefreshPartitionMap(), Configuration.ClientOptions.QueryAbortTimeout);
             if (table == null)
             {
                 //Refresh all the keyspaces and tables information
@@ -463,6 +468,7 @@ namespace Cassandra
                     Thread.Sleep(500);
                 }
                 Logger.Info(String.Format("Waited for schema agreement, still {0} schema versions in the cluster.", totalVersions));
+                TaskHelper.WaitToComplete(RefreshPartitionMap(), Configuration.ClientOptions.QueryAbortTimeout);
             }
             catch (Exception ex)
             {
@@ -478,6 +484,75 @@ namespace Cassandra
         internal void SetCassandraVersion(Version version)
         {
             _schemaParser = SchemaParser.GetInstance(version, this, GetUdtDefinitionAsync, _schemaParser);
+        }
+
+        /// <summary>
+        /// Refresh the partition map for all tables.
+        /// </summary>
+        internal async Task RefreshPartitionMap()
+        {
+            if (!Configuration.Policies.LoadBalancingPolicy.RequiresPartitionMap)
+            {
+                return;
+            }
+            var address2hosts = new Dictionary<IPAddress, Host>();
+            foreach (var host in AllHosts())
+            {
+                address2hosts.Add(host.Address.Address, host);
+            }
+            var rows = await ControlConnection.QueryAsync(SelectPartitions);
+            var splitsSource = new Dictionary<string, List<PartitionMetadata>>();
+            foreach (var row in rows)
+            {
+                var keyspace = row.GetValue<string>("keyspace_name");
+                var tableName = row.GetValue<string>("table_name");
+                var fullTableName = keyspace + "." + tableName;
+                var replicas = row.GetValue<IDictionary<IPAddress, string>>("replica_addresses");
+                var hosts = new List<Host>(replicas.Count);
+                foreach (var entry in replicas)
+                {
+                    Host host;
+                    if (!address2hosts.TryGetValue(entry.Key, out host))
+                    {
+                        continue;
+                    }
+                    var role = entry.Value;
+                    if (role == "LEADER")
+                    {
+                        hosts.Insert(0, host);
+                    }
+                    else if (role == "READ_REPLICA" || role == "FOLLOWER")
+                    {
+                        hosts.Add(host);
+                    }
+                }
+
+                var startKey = BytesToHashCode(row.GetValue<byte[]>("start_key"));
+                var endKey = BytesToHashCode(row.GetValue<byte[]>("end_key"));
+                List<PartitionMetadata> partitions;
+                if (!splitsSource.TryGetValue(fullTableName, out partitions))
+                {
+                    partitions = new List<PartitionMetadata>();
+                    splitsSource.Add(fullTableName, partitions);
+                }
+                partitions.Add(new PartitionMetadata(startKey, endKey, hosts));
+            }
+            var splits = new Dictionary<string, TableSplitMetadata>();
+            foreach (var entry in splitsSource)
+            {
+                splits.Add(entry.Key, new TableSplitMetadata(entry.Value));
+            }
+            TableSplitMetadata = splits;
+        }
+
+        private static int BytesToHashCode(byte[] input)
+        {
+            int result = 0;
+            foreach (var b in input)
+            {
+                result = (result << 8) | b;
+            }
+            return result;
         }
     }
 }

--- a/src/Cassandra/Metadata.cs
+++ b/src/Cassandra/Metadata.cs
@@ -495,10 +495,10 @@ namespace Cassandra
             {
                 return;
             }
-            var address2hosts = new Dictionary<IPAddress, Host>();
+            var addressToHosts = new Dictionary<IPAddress, Host>();
             foreach (var host in AllHosts())
             {
-                address2hosts.Add(host.Address.Address, host);
+                addressToHosts.Add(host.Address.Address, host);
             }
             var rows = await ControlConnection.QueryAsync(SelectPartitions);
             var splitsSource = new Dictionary<string, List<PartitionMetadata>>();
@@ -512,7 +512,7 @@ namespace Cassandra
                 foreach (var entry in replicas)
                 {
                     Host host;
-                    if (!address2hosts.TryGetValue(entry.Key, out host))
+                    if (!addressToHosts.TryGetValue(entry.Key, out host))
                     {
                         continue;
                     }

--- a/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections.Generic;

--- a/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/DCAwareRoundRobinPolicy.cs
@@ -267,5 +267,13 @@ namespace Cassandra
             }
             return hosts;
         }
+
+        public bool RequiresPartitionMap
+        {
+            get
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Cassandra/Policies/ILoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/ILoadBalancingPolicy.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System.Collections.Generic;
 

--- a/src/Cassandra/Policies/ILoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/ILoadBalancingPolicy.cs
@@ -64,5 +64,7 @@ namespace Cassandra
         ///  by this iterator in order, until the query has been sent successfully to one
         ///  of the host.</returns>
         IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query);
+
+        bool RequiresPartitionMap { get; }
     }
 }

--- a/src/Cassandra/Policies/Policies.cs
+++ b/src/Cassandra/Policies/Policies.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using Cassandra.YugaByte;
 
@@ -26,14 +40,14 @@ namespace Cassandra
         /// <summary>
         ///  The default load balancing policy. 
         /// <para> 
-        /// The default load balancing policy is <see cref="TokenAwarePolicy"/> with <see cref="DCAwareRoundRobinPolicy"/> as child policy.
+        /// The default load balancing policy is <see cref="PartitionAwarePolicy"/> with <see cref="DCAwareRoundRobinPolicy"/> as child policy.
         /// </para>
         /// </summary>
         public static ILoadBalancingPolicy DefaultLoadBalancingPolicy
         {
             get
             {
-                return new PartitionAwarePolicy();
+                return new PartitionAwarePolicy(new DCAwareRoundRobinPolicy(null, int.MaxValue));
             }
         }
 

--- a/src/Cassandra/Policies/Policies.cs
+++ b/src/Cassandra/Policies/Policies.cs
@@ -14,6 +14,8 @@
 //   limitations under the License.
 //
 
+using Cassandra.YugaByte;
+
 namespace Cassandra
 {
     /// <summary>
@@ -31,7 +33,7 @@ namespace Cassandra
         {
             get
             {
-                return new TokenAwarePolicy(new DCAwareRoundRobinPolicy());
+                return new PartitionAwarePolicy();
             }
         }
 

--- a/src/Cassandra/Policies/RetryLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/RetryLoadBalancingPolicy.cs
@@ -62,5 +62,13 @@ namespace Cassandra
                     Thread.Sleep((int) schedule.NextDelayMs());
             }
         }
+
+        public bool RequiresPartitionMap
+        {
+            get
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Cassandra/Policies/RetryLoadBalancingPolicy.cs
+++ b/src/Cassandra/Policies/RetryLoadBalancingPolicy.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections.Generic;

--- a/src/Cassandra/Policies/RoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/RoundRobinPolicy.cs
@@ -13,7 +13,22 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
-﻿using System.Collections.Generic;
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
+
+using System.Collections.Generic;
 using System.Threading;
 using System.Linq;
 

--- a/src/Cassandra/Policies/RoundRobinPolicy.cs
+++ b/src/Cassandra/Policies/RoundRobinPolicy.cs
@@ -82,5 +82,13 @@ namespace Cassandra
                 yield return hosts[(startIndex + i) % hosts.Length];
             }
         }
+
+        public bool RequiresPartitionMap
+        {
+            get
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Cassandra/Policies/TokenAwarePolicy.cs
+++ b/src/Cassandra/Policies/TokenAwarePolicy.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections.Generic;

--- a/src/Cassandra/Policies/TokenAwarePolicy.cs
+++ b/src/Cassandra/Policies/TokenAwarePolicy.cs
@@ -134,5 +134,13 @@ namespace Cassandra
                 yield return h;
             }
         }
+
+        public bool RequiresPartitionMap
+        {
+            get
+            {
+                return false;
+            }
+        }
     }
 }

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -274,5 +274,6 @@ namespace Cassandra
         {
             OutgoingPayload = payload;
             return this;
-        }    }
+        }
+    }
 }

--- a/src/Cassandra/PreparedStatement.cs
+++ b/src/Cassandra/PreparedStatement.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections.Generic;

--- a/src/Cassandra/QueryOptions.cs
+++ b/src/Cassandra/QueryOptions.cs
@@ -30,7 +30,7 @@ namespace Cassandra
         /// <summary>
         /// The default consistency level for queries: <c>ConsistencyLevel.LocalOne</c>.
         /// </summary>    
-        public const ConsistencyLevel DefaultConsistencyLevel = ConsistencyLevel.LocalOne;
+        public const ConsistencyLevel DefaultConsistencyLevel = ConsistencyLevel.YbStrong;
 
         /// <summary>
         /// The default serial consistency level for conditional updates: <c>ConsistencyLevel.Serial</c>.

--- a/src/Cassandra/QueryOptions.cs
+++ b/src/Cassandra/QueryOptions.cs
@@ -30,7 +30,7 @@ namespace Cassandra
         /// <summary>
         /// The default consistency level for queries: <c>ConsistencyLevel.LocalOne</c>.
         /// </summary>    
-        public const ConsistencyLevel DefaultConsistencyLevel = ConsistencyLevel.YbStrong;
+        public const ConsistencyLevel DefaultConsistencyLevel = ConsistencyLevel.YBStrong;
 
         /// <summary>
         /// The default serial consistency level for conditional updates: <c>ConsistencyLevel.Serial</c>.

--- a/src/Cassandra/QueryOptions.cs
+++ b/src/Cassandra/QueryOptions.cs
@@ -12,6 +12,21 @@
 //   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
+//
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 

--- a/src/Cassandra/RowPopulators/RowSetMetadata.cs
+++ b/src/Cassandra/RowPopulators/RowSetMetadata.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections.Generic;

--- a/src/Cassandra/RowPopulators/RowSetMetadata.cs
+++ b/src/Cassandra/RowPopulators/RowSetMetadata.cs
@@ -64,7 +64,8 @@ namespace Cassandra
         /// <summary>
         /// Tuple of n subtypes
         /// </summary>
-        Tuple = 0x0031
+        Tuple = 0x0031,
+        Json = 0x0080,
     }
 
     /// <summary>

--- a/src/Cassandra/Serialization/DataTypeParser.cs
+++ b/src/Cassandra/Serialization/DataTypeParser.cs
@@ -1,4 +1,19 @@
-﻿using System;
+﻿//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;

--- a/src/Cassandra/Serialization/DataTypeParser.cs
+++ b/src/Cassandra/Serialization/DataTypeParser.cs
@@ -80,7 +80,8 @@ namespace Cassandra.Serialization
             {"bigint", ColumnTypeCode.Bigint},
             {"decimal", ColumnTypeCode.Decimal},
             {"varint", ColumnTypeCode.Varint},
-            {"counter", ColumnTypeCode.Counter}
+            {"counter", ColumnTypeCode.Counter},
+            {"jsonb", ColumnTypeCode.Json},
         };
 
         private static readonly int SingleFqTypeNamesLength = SingleFqTypeNames.Keys.OrderByDescending(k => k.Length).First().Length;

--- a/src/Cassandra/Serialization/DictionarySerializer.cs
+++ b/src/Cassandra/Serialization/DictionarySerializer.cs
@@ -36,7 +36,6 @@ namespace Cassandra.Serialization
             var valueType = GetClrType(mapInfo.ValueTypeCode, mapInfo.ValueTypeInfo);
             var count = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);
             var dicType = typeof(SortedDictionary<,>).MakeGenericType(keyType, valueType);
-            IDictionary result;
             object comparer = null;
             // system.partitions contains dictonary with IPAddress key, that is not comparable.
             // So use custom comparer for it.
@@ -44,7 +43,14 @@ namespace Cassandra.Serialization
             {
                 comparer = IPAddressComparer.Instance;
             }
-            result = (IDictionary)(comparer == null ? Activator.CreateInstance(dicType) : Activator.CreateInstance(dicType, comparer));
+            IDictionary result;
+            if (comparer == null)
+            {
+                result = (IDictionary)Activator.CreateInstance(dicType);
+            } else
+            {
+                result = (IDictionary)Activator.CreateInstance(dicType, comparer);
+            }
             for (var i = 0; i < count; i++)
             {
                 var keyLength = DecodeCollectionLength((ProtocolVersion)protocolVersion, buffer, ref offset);

--- a/src/Cassandra/Serialization/DictionarySerializer.cs
+++ b/src/Cassandra/Serialization/DictionarySerializer.cs
@@ -13,11 +13,24 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
 using System.Net;
 
 namespace Cassandra.Serialization

--- a/src/Cassandra/Serialization/Primitive/JsonSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/JsonSerializer.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text;
+
+namespace Cassandra.Serialization.Primitive
+{
+    internal class JsonSerializer : TypeSerializer<string>
+    {
+        public override ColumnTypeCode CqlType
+        {
+            get { return ColumnTypeCode.Json; }
+        }
+
+        public override string Deserialize(ushort protocolVersion, byte[] buffer, int offset, int length, IColumnInfo typeInfo)
+        {
+            return Encoding.UTF8.GetString(buffer, offset, length);
+        }
+
+        public override byte[] Serialize(ushort protocolVersion, string value)
+        {
+            return Encoding.UTF8.GetBytes(value);
+        }
+    }
+}

--- a/src/Cassandra/Serialization/Primitive/JsonSerializer.cs
+++ b/src/Cassandra/Serialization/Primitive/JsonSerializer.cs
@@ -1,4 +1,16 @@
-﻿using System;
+﻿// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
 using System.Text;
 
 namespace Cassandra.Serialization.Primitive

--- a/src/Cassandra/Serialization/Serializer.cs
+++ b/src/Cassandra/Serialization/Serializer.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections;

--- a/src/Cassandra/Serialization/Serializer.cs
+++ b/src/Cassandra/Serialization/Serializer.cs
@@ -53,7 +53,8 @@ namespace Cassandra.Serialization
             { ColumnTypeCode.TinyInt, TypeSerializer.PrimitiveSbyteSerializer },
             { ColumnTypeCode.Uuid, TypeSerializer.PrimitiveGuidSerializer },
             { ColumnTypeCode.Varchar, TypeSerializer.PrimitiveStringSerializer },
-            { ColumnTypeCode.Varint, TypeSerializer.PrimitiveBigIntegerSerializer }
+            { ColumnTypeCode.Varint, TypeSerializer.PrimitiveBigIntegerSerializer },
+            { ColumnTypeCode.Json, TypeSerializer.PrimitiveJsonSerializer },
         };
 
         private readonly Dictionary<Type, ITypeSerializer> _primitiveSerializers = new Dictionary<Type, ITypeSerializer>();

--- a/src/Cassandra/Serialization/TypeSerializer.cs
+++ b/src/Cassandra/Serialization/TypeSerializer.cs
@@ -13,6 +13,20 @@
 //   See the License for the specific language governing permissions and
 //   limitations under the License.
 //
+//   The following only applies to changes made to this file as part of YugaByte development.
+//
+//      Portions Copyright (c) YugaByte, Inc.
+//
+//   Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file
+//   except in compliance with the License.  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software distributed under the
+//   License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+//   either express or implied.  See the License for the specific language governing permissions
+//   and limitations under the License.
+//
 
 using System;
 using System.Collections.Generic;

--- a/src/Cassandra/Serialization/TypeSerializer.cs
+++ b/src/Cassandra/Serialization/TypeSerializer.cs
@@ -47,6 +47,7 @@ namespace Cassandra.Serialization
         public static readonly TypeSerializer<string> PrimitiveStringSerializer = new StringSerializer(Encoding.UTF8);
         public static readonly TypeSerializer<string> PrimitiveAsciiStringSerializer = new StringSerializer(Encoding.ASCII);
         public static readonly TypeSerializer<TimeUuid> PrimitiveTimeUuidSerializer = new TimeUuidSerializer();
+        public static readonly TypeSerializer<string> PrimitiveJsonSerializer = new JsonSerializer();
 
         internal static readonly DateTimeOffset UnixStart = new DateTimeOffset(1970, 1, 1, 0, 0, 0, 0, TimeSpan.Zero);
 

--- a/src/Cassandra/YugaByte/Jenkins.cs
+++ b/src/Cassandra/YugaByte/Jenkins.cs
@@ -1,0 +1,128 @@
+﻿// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+/**
+* A hash function that returns a 64-bit hash value.
+*
+* Based on Bob Jenkins' new hash function (http://burtleburtle.net/bob/hash/evahash.html)
+*/
+public class Jenkins
+{
+    /// <summary>
+    /// Returns a 64-bit hash value of a byte sequence.
+    /// </summary>
+    /// <param name="k">the byte sequence</param>
+    /// <param name="initval">the initial (seed) value</param>
+    /// <returns>the 64-bit hash value</returns>
+    public static ulong Hash64(byte[] k, ulong initval)
+    {
+        // Set up the internal state
+        ulong a = 0xe08c1d668b756f82UL; // the golden ratio; an arbitrary value
+        ulong b = 0xe08c1d668b756f82UL;
+        ulong c = initval;             // variable initialization of internal state
+        int pos = 0;
+        // handle most of the key
+        while (k.Length - pos >= 24)
+        {
+            a += GetLong(k, pos); pos += 8;
+            b += GetLong(k, pos); pos += 8;
+            c += GetLong(k, pos); pos += 8;
+            // mix64(a, b, c);
+            a -= b; a -= c; a ^= (c >> 43);
+            b -= c; b -= a; b ^= (a << 9);
+            c -= a; c -= b; c ^= (b >> 8);
+            a -= b; a -= c; a ^= (c >> 38);
+            b -= c; b -= a; b ^= (a << 23);
+            c -= a; c -= b; c ^= (b >> 5);
+            a -= b; a -= c; a ^= (c >> 35);
+            b -= c; b -= a; b ^= (a << 49);
+            c -= a; c -= b; c ^= (b >> 11);
+            a -= b; a -= c; a ^= (c >> 12);
+            b -= c; b -= a; b ^= (a << 18);
+            c -= a; c -= b; c ^= (b >> 22);
+        }
+        // handle the last 23 bytes
+        c += (ulong)k.Length;
+        switch (k.Length - pos)
+        { // all the case statements fall through
+            case 23: c += GetByte(k, pos + 22) << 56; goto case 22;
+            case 22: c += GetByte(k, pos + 21) << 48; goto case 21;
+            case 21: c += GetByte(k, pos + 20) << 40; goto case 20;
+            case 20: c += GetByte(k, pos + 19) << 32; goto case 19;
+            case 19: c += GetByte(k, pos + 18) << 24; goto case 18;
+            case 18: c += GetByte(k, pos + 17) << 16; goto case 17;
+            case 17: c += GetByte(k, pos + 16) << 8; goto case 16;
+            // the first byte of c is reserved for the length
+            case 16: b += GetLong(k, pos + 8); a += GetLong(k, pos); break; // special handling
+            case 15: b += GetByte(k, pos + 14) << 48; goto case 14;
+            case 14: b += GetByte(k, pos + 13) << 40; goto case 13;
+            case 13: b += GetByte(k, pos + 12) << 32; goto case 12;
+            case 12: b += GetByte(k, pos + 11) << 24; goto case 11;
+            case 11: b += GetByte(k, pos + 10) << 16; goto case 10;
+            case 10: b += GetByte(k, pos + 9) << 8; goto case 9;
+            case 9: b += GetByte(k, pos + 8); goto case 8;
+            case 8: a += GetLong(k, pos); break; // special handling
+            case 7: a += GetByte(k, pos + 6) << 48; goto case 6;
+            case 6: a += GetByte(k, pos + 5) << 40; goto case 5;
+            case 5: a += GetByte(k, pos + 4) << 32; goto case 4;
+            case 4: a += GetByte(k, pos + 3) << 24; goto case 3;
+            case 3: a += GetByte(k, pos + 2) << 16; goto case 2;
+            case 2: a += GetByte(k, pos + 1) << 8; goto case 1;
+            case 1: a += GetByte(k, pos); break;
+                // case 0: nothing left to add
+        }
+        // mix64(a, b, c);
+        a -= b; a -= c; a ^= (c >> 43);
+        b -= c; b -= a; b ^= (a << 9);
+        c -= a; c -= b; c ^= (b >> 8);
+        a -= b; a -= c; a ^= (c >> 38);
+        b -= c; b -= a; b ^= (a << 23);
+        c -= a; c -= b; c ^= (b >> 5);
+        a -= b; a -= c; a ^= (c >> 35);
+        b -= c; b -= a; b ^= (a << 49);
+        c -= a; c -= b; c ^= (b >> 11);
+        a -= b; a -= c; a ^= (c >> 12);
+        b -= c; b -= a; b ^= (a << 18);
+        c -= a; c -= b; c ^= (b >> 22);
+        return c;
+    }
+    /**
+    * Retrieves a byte in a byte array as a long.
+    *
+    * @param k    the byte array
+    * @param pos  the byte position
+    * @return     the byte as long
+    */
+    private static ulong GetByte(byte[] k, int pos)
+    {
+        return k[pos];
+    }
+    /**
+    * Retrieves a long in a byte array in little-endian order.
+    *
+    * @param k    the byte array
+    * @param pos  the long position
+    * @return     the long in little-endian order
+    */
+    private static ulong GetLong(byte[] k, int pos)
+    {
+        return (GetByte(k, pos) |
+                GetByte(k, pos + 1) << 8 |
+                GetByte(k, pos + 2) << 16 |
+                GetByte(k, pos + 3) << 24 |
+                GetByte(k, pos + 4) << 32 |
+                GetByte(k, pos + 5) << 40 |
+                GetByte(k, pos + 6) << 48 |
+                GetByte(k, pos + 7) << 56);
+    }
+}

--- a/src/Cassandra/YugaByte/PartitionAwarePolicy.cs
+++ b/src/Cassandra/YugaByte/PartitionAwarePolicy.cs
@@ -1,5 +1,4 @@
-﻿
-// Copyright (c) YugaByte, Inc.
+﻿// Copyright (c) YugaByte, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
 // in compliance with the License.  You may obtain a copy of the License at
@@ -13,14 +12,11 @@
 //
 
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text;
-using Cassandra.Serialization;
 
 namespace Cassandra.YugaByte
 {
@@ -28,10 +24,6 @@ namespace Cassandra.YugaByte
     {
         private readonly ILoadBalancingPolicy _childPolicy;
         private ICluster _cluster;
-
-        public PartitionAwarePolicy() : this(new DCAwareRoundRobinPolicy(null, int.MaxValue))
-        {
-        }
 
         public PartitionAwarePolicy(ILoadBalancingPolicy childPolicy)
         {

--- a/src/Cassandra/YugaByte/PartitionAwarePolicy.cs
+++ b/src/Cassandra/YugaByte/PartitionAwarePolicy.cs
@@ -26,8 +26,17 @@ namespace Cassandra.YugaByte
 {
     public class PartitionAwarePolicy : ILoadBalancingPolicy
     {
-        private readonly ILoadBalancingPolicy _childPolicy = new DCAwareRoundRobinPolicy(null, int.MaxValue);
+        private readonly ILoadBalancingPolicy _childPolicy;
         private ICluster _cluster;
+
+        public PartitionAwarePolicy() : this(new DCAwareRoundRobinPolicy(null, int.MaxValue))
+        {
+        }
+
+        public PartitionAwarePolicy(ILoadBalancingPolicy childPolicy)
+        {
+            _childPolicy = childPolicy;
+        }
 
         public void Initialize(ICluster cluster)
         {
@@ -104,7 +113,7 @@ namespace Cassandra.YugaByte
 
             var hosts = Enumerable.ToArray(tableSplitMetadata.GetHosts(key));
             var consistencyLevel = boundStatement.ConsistencyLevel ?? _cluster.Configuration.QueryOptions.GetConsistencyLevel();
-            if (consistencyLevel == ConsistencyLevel.YbConsistentPrefix)
+            if (consistencyLevel == ConsistencyLevel.YBConsistentPrefix)
             {
                 Shuffle(hosts);
             }

--- a/src/Cassandra/YugaByte/PartitionAwarePolicy.cs
+++ b/src/Cassandra/YugaByte/PartitionAwarePolicy.cs
@@ -1,0 +1,287 @@
+﻿
+// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Text;
+using Cassandra.Serialization;
+
+namespace Cassandra.YugaByte
+{
+    public class PartitionAwarePolicy : ILoadBalancingPolicy
+    {
+        private readonly ILoadBalancingPolicy _childPolicy = new DCAwareRoundRobinPolicy(null, int.MaxValue);
+        private ICluster _cluster;
+
+        public void Initialize(ICluster cluster)
+        {
+            _childPolicy.Initialize(cluster);
+            _cluster = cluster;
+        }
+
+        public HostDistance Distance(Host host)
+        {
+            return _childPolicy.Distance(host);
+        }
+
+        public IEnumerable<Host> NewQueryPlan(string keyspace, IStatement query)
+        {
+            IEnumerable<Host> result = null;
+            var boundStatement = query as BoundStatement;
+            if (boundStatement != null)
+            {
+                result = NewQueryPlanImpl(keyspace, boundStatement);
+            }
+            else
+            {
+                var batchStatement = query as BatchStatement;
+                if (batchStatement != null)
+                {
+                    result = NewQueryPlanImpl(keyspace, batchStatement);
+                }
+            }
+            if (result == null)
+            {
+                result = _childPolicy.NewQueryPlan(keyspace, query);
+            }
+            return result;
+        }
+
+        private IEnumerable<Host> NewQueryPlanImpl(string keyspace, BatchStatement batchStatement)
+        {
+            foreach (var query in batchStatement.Queries)
+            {
+                var boundStatement = query as BoundStatement;
+                if (boundStatement != null)
+                {
+                    var plan = NewQueryPlanImpl(keyspace, boundStatement);
+                    if (plan != null)
+                        return plan;
+                }
+            }
+            return null;
+        }
+
+        private IEnumerable<Host> NewQueryPlanImpl(string keyspace, BoundStatement boundStatement)
+        {
+            var pstmt = boundStatement.PreparedStatement;
+            var query = pstmt.Cql;
+            var variables = pstmt.Variables;
+
+            // Look up the hosts for the partition key. Skip statements that do not have bind variables.
+            if (variables.Columns.Length == 0)
+            {
+                return null;
+            }
+            int key = GetKey(boundStatement);
+            if (key < 0)
+            {
+                return null;
+            }
+
+            var fullTableName = variables.Keyspace + "." + variables.Columns[0].Table;
+            TableSplitMetadata tableSplitMetadata;
+            if (!_cluster.Metadata.TableSplitMetadata.TryGetValue(fullTableName, out tableSplitMetadata))
+            {
+                return null;
+            }
+
+            var hosts = Enumerable.ToArray(tableSplitMetadata.GetHosts(key));
+            var consistencyLevel = boundStatement.ConsistencyLevel ?? _cluster.Configuration.QueryOptions.GetConsistencyLevel();
+            if (consistencyLevel == ConsistencyLevel.YbConsistentPrefix)
+            {
+                Shuffle(hosts);
+            }
+            var strongConsistency = consistencyLevel.IsStrong();
+            return IterateUpHosts(keyspace, hosts, strongConsistency);
+        }
+
+        private IEnumerable<Host> IterateUpHosts(string keyspace, Host[] hosts, bool strongConsistency)
+        {
+            foreach (var host in hosts)
+            {
+                if (host.IsUp && (strongConsistency || _childPolicy.Distance(host) == HostDistance.Local))
+                {
+                    yield return host;
+                }
+            }
+
+            foreach (var host in _childPolicy.NewQueryPlan(keyspace, null))
+            {
+                if (Array.IndexOf(hosts, host) == -1 && (strongConsistency || _childPolicy.Distance(host) == HostDistance.Local))
+                {
+                    yield return host;
+                }
+            }
+        }
+
+        private static void Shuffle<T>(T[] array) {
+            var rng = new Random();
+            int n = array.Length;
+            while (n > 1)
+            {
+                int k = rng.Next(n--);
+                T temp = array[n];
+                array[n] = array[k];
+                array[k] = temp;
+            }
+        }
+
+        public static int GetKey(BoundStatement boundStatement)
+        {
+            PreparedStatement pstmt = boundStatement.PreparedStatement;
+            var hashIndexes = pstmt.RoutingIndexes;
+
+            if (hashIndexes == null || hashIndexes.Length == 0)
+            {
+                return -1;
+            }
+
+            try
+            {
+                // Compute the hash key bytes, i.e. <h1><h2>...<h...>.
+                var variables = pstmt.Variables;
+                var values = boundStatement.QueryValues;
+                using (var stream = new MemoryStream())
+                using (var writer = new BinaryWriter(stream))
+                {
+                    foreach (var index in hashIndexes)
+                    {
+                        var type = variables.Columns[index].TypeCode;
+                        var value = values[index];
+                        WriteTypedValue(type, value, writer);
+                    }
+                    return BytesToKey(stream.ToArray());
+                }
+            } catch (InvalidCastException)
+            {
+                // We don't support cases when type of bound value does not match column type.
+                return -1;
+            }
+        }
+
+        public static long YBHashCode(BoundStatement boundStatement)
+        {
+            var hash = GetKey(boundStatement);
+            if (hash == -1)
+            {
+                return -1;
+            }
+            return (long)(hash ^ 0x8000) << 48;
+        }
+
+        private static int BytesToKey(byte[] bytes)
+        {
+            ulong Seed = 97;
+            ulong h = Jenkins.Hash64(bytes, Seed);
+            ulong h1 = h >> 48;
+            ulong h2 = 3 * (h >> 32);
+            ulong h3 = 5 * (h >> 16);
+            ulong h4 = 7 * (h & 0xffff);
+            int result = (int)((h1 ^ h2 ^ h3 ^ h4) & 0xffff);
+            // Console.WriteLine("Bytes to key {0}: {1}", BitConverter.ToString(bytes).Replace("-", ""), result);
+            return result;
+        }
+
+        public static string ByteArrayToString(byte[] ba)
+        {
+            return BitConverter.ToString(ba).Replace("-", "");
+        }
+
+        private static void WriteTypedValue(ColumnTypeCode type, object value, BinaryWriter writer)
+        {
+            switch (type)
+            {
+                case ColumnTypeCode.Ascii:
+                    writer.Write(Encoding.ASCII.GetBytes((string)value));
+                    break;
+                case ColumnTypeCode.Varchar:
+                case ColumnTypeCode.Text:
+                    writer.Write(Encoding.UTF8.GetBytes((string)value));
+                    break;
+                case ColumnTypeCode.Bigint:
+                    writer.Write(IPAddress.HostToNetworkOrder((long)value));
+                    break;
+                case ColumnTypeCode.Blob:
+                    writer.Write((byte[])value);
+                    break;
+                case ColumnTypeCode.Boolean:
+                    writer.Write((bool)value);
+                    break;
+                case ColumnTypeCode.Double:
+                    writer.Write(IPAddress.HostToNetworkOrder(BitConverter.DoubleToInt64Bits((double)value)));
+                    break;
+                case ColumnTypeCode.Float:
+                    var bytes = BitConverter.GetBytes((float)value);
+                    Array.Reverse(bytes);
+                    writer.Write(bytes);
+                    break;
+                case ColumnTypeCode.Int:
+                    writer.Write(IPAddress.HostToNetworkOrder((int)value));
+                    break;
+                case ColumnTypeCode.Timestamp:
+                    // We should multiply by 1000 after division, because passing timestamp from Cassandra to YugaByte would also
+                    // loose microsecond precision.
+                    var milliseconds = ((DateTimeOffset)value - TypeSerializer.UnixStart).Ticks / TimeSpan.TicksPerMillisecond * 1000;
+                    writer.Write(IPAddress.HostToNetworkOrder(milliseconds));
+                    break;
+                case ColumnTypeCode.Uuid:
+                    writer.Write(TypeSerializer.GuidShuffle(((Guid)value).ToByteArray()));
+                    break;
+                case ColumnTypeCode.Timeuuid:
+                    writer.Write(TypeSerializer.GuidShuffle(((TimeUuid)value).ToByteArray()));
+                    break;
+                case ColumnTypeCode.Inet:
+                    writer.Write(((IPAddress)value).GetAddressBytes());
+                    break;
+                case ColumnTypeCode.Date:
+                    writer.Write(TypeSerializer.PrimitiveLocalDateSerializer.Serialize(0, (LocalDate)value));
+                    break;
+                case ColumnTypeCode.Time:
+                    writer.Write(IPAddress.HostToNetworkOrder(((LocalTime)value).TotalNanoseconds));
+                    break;
+                case ColumnTypeCode.SmallInt:
+                    writer.Write(IPAddress.HostToNetworkOrder((short)value));
+                    break;
+                case ColumnTypeCode.TinyInt:
+                    writer.Write((sbyte)value);
+                    break;
+                // Udt
+                case ColumnTypeCode.Counter:
+                case ColumnTypeCode.Custom:
+                case ColumnTypeCode.Decimal:
+                case ColumnTypeCode.Tuple:
+                case ColumnTypeCode.Varint:
+                case ColumnTypeCode.List:
+                case ColumnTypeCode.Map:
+                case ColumnTypeCode.Set:
+                    throw new InvalidTypeException("Datatype " + type.ToString() + " not supported in a partition key column");
+                default:
+                    Console.WriteLine(string.Format("type={0}, value={1}, value.type={2}", type, value, value.GetType()));
+                    break;
+            }
+        }
+
+        public bool RequiresPartitionMap
+        {
+            get
+            {
+                return true;
+            }
+        }
+    }
+}

--- a/src/Cassandra/YugaByte/PartitionMetadata.cs
+++ b/src/Cassandra/YugaByte/PartitionMetadata.cs
@@ -1,0 +1,54 @@
+﻿// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cassandra.YugaByte
+{
+    /// <summary>
+    /// The metadata for one table partition. It maintains the partition's range (start and end key) and
+    /// hosts (leader and followers).
+    /// </summary>
+    public struct PartitionMetadata
+    {
+        // The partition start -- inclusive bound.
+        public int StartKey { get; private set; }
+        // The partition end -- exclusive bound.
+        public int EndKey { get; private set; }
+        // The list of hosts -- first one should be the leader, then the followers in no particular order.
+        // TODO We should make the leader explicit here and in the return type of the getQueryPlan method
+        // to be able to distinguish the case where the leader is missing so the hosts are all followers.
+        public IEnumerable<Host> Hosts { get; private set; }
+
+        public bool Valid {
+            get
+            {
+                return StartKey >= 0;
+            }
+        }
+
+        /// <summary>Creates a new PartitionMetadata</summary>
+        public PartitionMetadata(int startKey, int endKey, IList<Host> hosts)
+        {
+            StartKey = startKey;
+            EndKey = endKey;
+            Hosts = (hosts != null) ? new List<Host>(hosts) : Enumerable.Empty<Host>();
+        }
+
+        public override string ToString()
+        {
+            return string.Format("[{0}, {1}) -> {2}", StartKey, EndKey, string.Join(", ", Hosts));
+        }
+    }
+}

--- a/src/Cassandra/YugaByte/PartitionMetadata.cs
+++ b/src/Cassandra/YugaByte/PartitionMetadata.cs
@@ -31,19 +31,12 @@ namespace Cassandra.YugaByte
         // to be able to distinguish the case where the leader is missing so the hosts are all followers.
         public IEnumerable<Host> Hosts { get; private set; }
 
-        public bool Valid {
-            get
-            {
-                return StartKey >= 0;
-            }
-        }
-
         /// <summary>Creates a new PartitionMetadata</summary>
         public PartitionMetadata(int startKey, int endKey, IList<Host> hosts)
         {
             StartKey = startKey;
             EndKey = endKey;
-            Hosts = (hosts != null) ? new List<Host>(hosts) : Enumerable.Empty<Host>();
+            Hosts = hosts != null ? new List<Host>(hosts) : Enumerable.Empty<Host>();
         }
 
         public override string ToString()

--- a/src/Cassandra/YugaByte/TableSplitMetadata.cs
+++ b/src/Cassandra/YugaByte/TableSplitMetadata.cs
@@ -1,0 +1,75 @@
+﻿// Copyright (c) YugaByte, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+// in compliance with the License.  You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed under the License
+// is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+// or implied.  See the License for the specific language governing permissions and limitations
+// under the License.
+//
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Cassandra.YugaByte
+{
+    /**
+    * The partition split for a table. It maintains a map from start key to partition metadata for each
+    * partition split of the table.
+    */
+    public class TableSplitMetadata
+    {
+        // Map from start-key to partition metadata representing the partition split of a table.
+        private readonly int[] _startKeys;
+        private readonly PartitionMetadata[] _partitions;
+        /// <summary>
+        /// Creates a new {@code TableSplitMetadata}.
+        /// </summary>
+        public TableSplitMetadata(IEnumerable<PartitionMetadata> source)
+        {
+            _partitions = Enumerable.ToArray(source);
+            Array.Sort(_partitions, (lhs, rhs) =>
+            {
+                return lhs.StartKey - rhs.StartKey;
+            });
+            _startKeys = new int[_partitions.Length];
+            for (int i = 0; i != _partitions.Length; ++i)
+            {
+                _startKeys[i] = _partitions[i].StartKey;
+            }
+        }
+
+        /// <summary>
+        /// Returns the partition metadata for the partition key in the given table.
+        /// </summary>
+        /// <param name="key">the partition key</param>
+        /// <returns>the partition metadata for the partition key, or {@code null} when there is no
+        /// partition information available</returns>
+        public PartitionMetadata? GetPartitionMetadata(int key)
+        {
+            int index = Array.BinarySearch(_startKeys, key);
+            if (index < 0)
+            {
+                index = ~index - 1;
+            }
+            if (index < 0) // key less than minimal start key
+            {
+                return null;
+            }
+            return _partitions[index];
+        }
+
+        /// <summary>
+        /// Returns the hosts for the partition key in the given table.
+        /// </summary>
+        /// <param name="key">the partition key</param>
+        /// <returns>the hosts for the partition key, or an empty list when there is no hosts information available</returns>
+        public IEnumerable<Host> GetHosts(int key)
+        {
+            return GetPartitionMetadata(key)?.Hosts;
+        }
+    }
+}

--- a/src/Cassandra/YugaByte/TableSplitMetadata.cs
+++ b/src/Cassandra/YugaByte/TableSplitMetadata.cs
@@ -10,6 +10,7 @@
 // or implied.  See the License for the specific language governing permissions and limitations
 // under the License.
 //
+
 using System;
 using System.Collections.Generic;
 using System.Linq;


### PR DESCRIPTION
Implemented partition aware policy in C# driver.
All primitive and frozen types are supported.
Ported policy tests from Java to C#.

Added JSON support to C# driver.
Ported JSON test from Java to C#.